### PR TITLE
Fix active player count not updating in automated SVG generation

### DIFF
--- a/src/generate-svg.js
+++ b/src/generate-svg.js
@@ -171,6 +171,10 @@ class FoxholeSVGGenerator {
       logger.info(`Resistance phase detected. ${this.activeMapsList.length} active maps.`);
     }
 
+    // Fetch fresh active players count
+    this.activePlayers = await this.fetchActivePlayers();
+    logger.debug(`Active players: ${this.activePlayers}`);
+
     // Fetch data for all regions
     for (const region of HEX_REGIONS) {
       // Find static data for this region from the main project's static.json


### PR DESCRIPTION
## Summary
Fixes the issue where active player count was stuck at a stale value in automated SVG generation.

## Problem
Previously, the active player count was only fetched once during generator initialization and never refreshed. This caused the automated Terminus poster to display stale player counts, while manual regeneration via the web UI worked correctly.

## Solution
Added player count refresh in `fetchAllMapData()` so that every SVG generation fetches current active player data from the Steam Charts API.

## Changes
- `src/generate-svg.js`: Added `fetchActivePlayers()` call in `fetchAllMapData()`
- Added debug logging for player count

## Testing
- Container rebuilt and restarted
- Verified latest SVG shows current player count (3,403)
- Automated updates now refresh player count every minute

🤖 Generated with [Claude Code](https://claude.com/claude-code)